### PR TITLE
Improve home hybrid map compatibility

### DIFF
--- a/lib/custom_code/widgets/hybrid_ride_map.dart
+++ b/lib/custom_code/widgets/hybrid_ride_map.dart
@@ -84,6 +84,7 @@ class _HybridRideMapState extends State<HybridRideMap> {
   void didUpdateWidget(covariant HybridRideMap oldWidget) {
     super.didUpdateWidget(oldWidget);
     _refreshLayers();
+    _animateToUserIfNeeded();
   }
 
   @override
@@ -106,6 +107,13 @@ class _HybridRideMapState extends State<HybridRideMap> {
       final pos = await Geolocator.getCurrentPosition();
       if (!mounted) return;
       setState(() => _me = pos);
+
+      // Ensure the map centers on the user's initial position and
+      // draws any required markers or polylines as soon as a
+      // location is available. This keeps behaviour consistent
+      // across iOS (Apple Maps) and Android (Google Maps).
+      _animateToUserIfNeeded();
+      _refreshLayers();
 
       _posSub?.cancel();
       _posSub = Geolocator.getPositionStream(


### PR DESCRIPTION
## Summary
- refresh hybrid ride map immediately on init so user position renders
- animate map to user when widget updates for consistent iOS/Android behavior

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a61756e698833197bbb6b441219d86