### PR TITLE
refactor: use centralized repositories

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,14 +1,5 @@
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-        // >>> Transistorsoft (necessário para background_fetch / flutter_background_geolocation)
-        maven { url "https://maven.transistorsoft.com" }
-        // (opcional) espelho, caso a URL acima esteja bloqueada no ambiente de build
-        maven { url "https://maven.transistorsoft.com/maven2" }
-    }
-}
 
+// Repositories are configured in settings.gradle via dependencyResolutionManagement
 rootProject.buildDir = '../build'
 
 subprojects {


### PR DESCRIPTION
## Summary
- remove project-level repository definitions from Android build script
- document that repositories are managed via settings.gradle

## Testing
- `flutter test` *(fails: command not found)*
- `gradle -p android tasks` *(fails: missing local.properties)*

------
https://chatgpt.com/codex/tasks/task_b_68ac6717caf88331b403c3ac2c2ec835