### PR TITLE
fix: configure Transistorsoft Maven repo for background fetch

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,6 +2,8 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://maven.transistorsoft.com' }
+        maven { url 'https://jitpack.io' }
     }
 }
 

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -7,9 +7,12 @@ pluginManagement {
         return path
     }()
     includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
-    repositories { google(); mavenCentral(); gradlePluginPortal()
+    repositories {
+        google(); mavenCentral(); gradlePluginPortal()
         maven { url "${flutterSdkPath}/bin/cache/artifacts/engine" }
         maven { url "https://storage.googleapis.com/download.flutter.io" }
+        maven { url "https://maven.transistorsoft.com" }
+        maven { url "https://jitpack.io" }
     }
 }
 plugins {
@@ -24,6 +27,8 @@ dependencyResolutionManagement {
         google(); mavenCentral()
         maven { url "${flutterSdkPath}/bin/cache/artifacts/engine" }
         maven { url "https://storage.googleapis.com/download.flutter.io" }
+        maven { url "https://maven.transistorsoft.com" }
+        maven { url "https://jitpack.io" }
     }
 }
 include ":app"


### PR DESCRIPTION
## Summary
- add Transistorsoft and JitPack Maven repositories to Android build scripts

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_b_68ac68c1ca80833198b57502026e5e2e