### PR TITLE
Improve map appearance and card form persistence

### DIFF
--- a/lib/components/card_payment_widget.dart
+++ b/lib/components/card_payment_widget.dart
@@ -285,9 +285,22 @@ class _CardPaymentWidgetState extends State<CardPaymentWidget> {
                           tokenizationKey: 'sandbox_ck9vkcgg_brg8dhjg5tqpw496',
                           chargeOnConfirm: widget.pagamento,
                           onTextField: (creditCardTextfield) async {
-                            FFAppState()
-                                .addToCreditCardSalves(creditCardTextfield);
-                            safeSetState(() {});
+                            FFAppState().update(() {
+                              FFAppState().cardNumber =
+                                  getJsonField(creditCardTextfield, r'$.number')
+                                      .toString();
+                              FFAppState().cardExpiry =
+                                  getJsonField(creditCardTextfield, r'$.expiry')
+                                      .toString();
+                              FFAppState().cardCvv =
+                                  getJsonField(creditCardTextfield, r'$.cvv')
+                                      .toString();
+                              FFAppState().cardHolder =
+                                  getJsonField(creditCardTextfield, r'$.holder')
+                                      .toString();
+                              FFAppState().addToCreditCardSalves(
+                                  creditCardTextfield);
+                            });
                           },
                         ),
                       ),

--- a/lib/custom_code/widgets/card_form_f_f.dart
+++ b/lib/custom_code/widgets/card_form_f_f.dart
@@ -319,6 +319,7 @@ class _CardFormFFState extends State<CardFormFF> {
       'expYear': data.year, // "YYYY"
 
       // Informação não sensível, útil pro UI
+      'cvv': data.cvv,
       'cvvLength': data.cvv.length,
 
       // Status/form

--- a/lib/custom_code/widgets/picker_map.dart
+++ b/lib/custom_code/widgets/picker_map.dart
@@ -914,6 +914,10 @@ class _PickerMapState extends State<PickerMap> with TickerProviderStateMixin {
         endCap: gmaps.Cap.roundCap,
         jointType: gmaps.JointType.round,
         geodesic: true,
+        patterns: const [
+          gmaps.PatternItem.dash(20),
+          gmaps.PatternItem.gap(10),
+        ],
       );
 
   // ---------------- Lifecycle ----------------

--- a/lib/home5/home5_widget.dart
+++ b/lib/home5/home5_widget.dart
@@ -270,7 +270,7 @@ class _Home5WidgetState extends State<Home5Widget>
     context.watch<FFAppState>();
     if (currentUserLocationValue == null) {
       return Container(
-        color: FlutterFlowTheme.of(context).primaryBackground,
+        color: FlutterFlowTheme.of(context).primaryText,
         child: Center(
           child: SizedBox(
             width: 50.0,
@@ -304,7 +304,7 @@ class _Home5WidgetState extends State<Home5Widget>
                     LatLng(13.106061, -59.613158),
                 markerColor: GoogleMarkerColor.violet,
                 mapType: MapType.normal,
-                style: GoogleMapStyle.standard,
+                style: GoogleMapStyle.night,
                 initialZoom: 14.0,
                 allowInteraction: true,
                 allowZoom: false,


### PR DESCRIPTION
## Summary
- Remove white flash by initializing Home5 with dark loading screen and map style
- Add dash pattern to route polyline for a nicer map effect
- Include CVV in CardFormFF payload and store card details in app state

## Testing
- `dart format lib/home5/home5_widget.dart lib/custom_code/widgets/picker_map.dart lib/custom_code/widgets/card_form_f_f.dart lib/components/card_payment_widget.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b9ff81c5708331a032727ca0940d35