### PR TITLE
Focus destination field during voice input

### DIFF
--- a/lib/custom_code/widgets/address_picker.dart
+++ b/lib/custom_code/widgets/address_picker.dart
@@ -460,15 +460,21 @@ class _AddressPickerState extends State<AddressPicker> {
       setState(() => _isListening = false);
       return;
     }
-    setState(() => _isListening = true);
+    _destFocus.requestFocus();
+    setState(() {
+      _isListening = true;
+      _editingPickup = false;
+    });
     await _speech.listen(
       listenMode: stt.ListenMode.dictation,
       onResult: (res) {
         final text = res.recognizedWords.trim();
-        _destCtrl.text = text; // sempre mostra o texto NO CAMPO
+        _destCtrl
+          ..text = text
+          ..selection = TextSelection.fromPosition(
+              TextPosition(offset: text.length));
         setState(() {});
         if (text.isNotEmpty) {
-          _editingPickup = false;
           _kickSearch(); // puxa sugestões com bias no user
         }
       },


### PR DESCRIPTION
## Summary
- Request destination field focus when starting voice input so spoken text appears instantly
- Preserve cursor at end and trigger search suggestions for transcribed text

## Testing
- `flutter test` *(fails: Method invocation is not a constant expression in picker_map.dart)*

------
https://chatgpt.com/codex/tasks/task_b_68ba02832c348331a1d446b0ae625eea