### PR TITLE
fix: remove const patterns list

### DIFF
--- a/lib/custom_code/widgets/picker_map.dart
+++ b/lib/custom_code/widgets/picker_map.dart
@@ -914,7 +914,10 @@ class _PickerMapState extends State<PickerMap> with TickerProviderStateMixin {
         endCap: gmaps.Cap.roundCap,
         jointType: gmaps.JointType.round,
         geodesic: true,
-        patterns: const [
+        // A non-const list is required here because PatternItem constructors
+        // are not compile-time constants. Using `const` caused a build failure
+        // when the polyline was compiled for iOS.
+        patterns: [
           gmaps.PatternItem.dash(20),
           gmaps.PatternItem.gap(10),
         ],


### PR DESCRIPTION
## Summary
- avoid using const list for polyline patterns to prevent non-constant method invocation

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ba0881c6188331b72dc43097061077