### PR TITLE
Fix PickerMap visibility on native platforms

### DIFF
--- a/lib/custom_code/widgets/picker_map.dart
+++ b/lib/custom_code/widgets/picker_map.dart
@@ -1059,6 +1059,8 @@ class _PickerMapState extends State<PickerMap> with TickerProviderStateMixin {
                 onMapCreated: (c) async {
                   _nativeController = c;
                   _mapReady = true;
+                  _styleReady = true;
+                  _firstIdle = true;
                   _maybeReveal();
                   _scheduleFit();
                   await _syncNativeMap();


### PR DESCRIPTION
## Summary
- ensure PickerMap unveils map on Android/iOS by setting style and idle flags on native map creation

## Testing
- `dart format lib/custom_code/widgets/picker_map.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68bad4f7a18883319a6120467b397711