### PR TITLE
Fix Android native map lifecycle

### DIFF
--- a/android/app/src/main/kotlin/com/example/my_project/NativeGoogleMap.kt
+++ b/android/app/src/main/kotlin/com/example/my_project/NativeGoogleMap.kt
@@ -28,6 +28,10 @@ class NativeGoogleMap(
     init {
         channel.setMethodCallHandler(this)
         mapView.onCreate(null)
+        // Ensure the MapView lifecycle is properly started so the
+        // GoogleMap instance can render correctly.
+        // Some devices require onStart to be invoked before onResume.
+        mapView.onStart()
         mapView.onResume()
         mapView.getMapAsync { g ->
             googleMap = g
@@ -43,6 +47,10 @@ class NativeGoogleMap(
     override fun getView(): View = mapView
 
     override fun dispose() {
+        // Mirror the lifecycle methods called in init to avoid
+        // memory leaks and ensure the map cleans up correctly.
+        mapView.onPause()
+        mapView.onStop()
         mapView.onDestroy()
     }
 


### PR DESCRIPTION
## Summary
- ensure MapView lifecycle is started with onStart before onResume
- clean up MapView with onPause/onStop in dispose

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68bae5a035dc83319e453458528453ce