### PR TITLE
Reveal picker map immediately when style loads

### DIFF
--- a/lib/custom_code/widgets/picker_map.dart
+++ b/lib/custom_code/widgets/picker_map.dart
@@ -1112,7 +1112,12 @@ class _PickerMapState extends State<PickerMap> with TickerProviderStateMixin {
 
   void _maybeReveal() {
     if (!_veilVisible) return;
-    if (_styleReady && _firstIdle && mounted) {
+    // Reveal the map as soon as the style is ready. Previously this method
+    // also waited for the first camera idle callback, which could prevent the
+    // map from ever showing if that event wasn't fired. By removing that
+    // requirement we ensure the veil is lifted immediately after the map is
+    // created, allowing the map to be visible right when the widget starts.
+    if (_styleReady && mounted) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) setState(() => _veilVisible = false);
       });


### PR DESCRIPTION
## Summary
- Show picker map immediately by removing first camera idle dependency when revealing map

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_b_68baed2e57888331b5895d94147fd616