### PR TITLE
refactor: remove google map from home5

### DIFF
--- a/lib/home5/home5_model.dart
+++ b/lib/home5/home5_model.dart
@@ -1,5 +1,4 @@
 import '/components/navbar_widget.dart';
-import '/flutter_flow/flutter_flow_google_map.dart';
 import '/flutter_flow/flutter_flow_util.dart';
 import '/index.dart';
 import 'home5_widget.dart' show Home5Widget;
@@ -24,9 +23,6 @@ class Home5Model extends FlutterFlowModel<Home5Widget> {
   List<dynamic>? locationPerto;
   // Stores action output result for [Custom Action - localGreetingAction] action in Home5 widget.
   String? fraseInicial;
-  // State field(s) for GoogleMap widget.
-  LatLng? googleMapsCenter;
-  final googleMapsController = Completer<GoogleMapController>();
   // Stores action output result for [Custom Action - geocodeAddress] action in Container widget.
   dynamic geolocatoraddressonchoose;
   DateTime? datePicked;

--- a/lib/home5/home5_widget.dart
+++ b/lib/home5/home5_widget.dart
@@ -3,7 +3,6 @@ import '/backend/backend.dart';
 import '/components/navbar_widget.dart';
 import '/components/select_location_widget.dart';
 import '/flutter_flow/flutter_flow_animations.dart';
-import '/flutter_flow/flutter_flow_google_map.dart';
 import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
 import '/custom_code/actions/index.dart' as actions;
@@ -295,28 +294,6 @@ class _Home5WidgetState extends State<Home5Widget>
         backgroundColor: FlutterFlowTheme.of(context).primaryText,
         body: Stack(
           children: [
-            Opacity(
-              opacity: 0.0,
-              child: FlutterFlowGoogleMap(
-                controller: _model.googleMapsController,
-                onCameraIdle: (latLng) => _model.googleMapsCenter = latLng,
-                initialLocation: _model.googleMapsCenter ??=
-                    LatLng(13.106061, -59.613158),
-                markerColor: GoogleMarkerColor.violet,
-                mapType: MapType.normal,
-                style: GoogleMapStyle.standard,
-                initialZoom: 14.0,
-                allowInteraction: true,
-                allowZoom: false,
-                showZoomControls: false,
-                showLocation: true,
-                showCompass: false,
-                showMapToolbar: false,
-                showTraffic: false,
-                centerMapOnMarkerTap: false,
-                mapTakesGesturePreference: false,
-              ),
-            ),
             PointerInterceptor(
               intercepting: isWeb,
               child: Padding(


### PR DESCRIPTION
## Summary
- remove hidden Flutter GoogleMap from Home5
- drop GoogleMap controller state from Home5Model

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c02f4c7b608331af1ad021b9aafb8d