### PR TITLE
feat: support native map padding and integrate picker map

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -90,4 +90,5 @@ dependencies {
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.4'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:2.1.0"
     implementation 'io.card:android-sdk:5.5.1'
+    implementation 'com.google.android.gms:play-services-maps:18.2.0'
 }

--- a/android/app/src/main/kotlin/com/quicky/ridebahamas/PickerMapNativeView.kt
+++ b/android/app/src/main/kotlin/com/quicky/ridebahamas/PickerMapNativeView.kt
@@ -73,6 +73,9 @@ class PickerMapNativeView(context: Context, messenger: BinaryMessenger, id: Int)
         val pos = LatLng(lat, lng)
         map?.moveCamera(CameraUpdateFactory.newLatLngZoom(pos, 14f))
 
+        val pad = (args["brandSafePaddingBottom"] as? Double)?.toInt() ?: 0
+        map?.setPadding(0, 0, 0, pad)
+
         // user marker
         val userPhoto = args["userPhotoUrl"] as String?
         if (userMarker == null) {

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -33,6 +33,7 @@ target 'Runner' do
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
   pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '11.13.0'
+  pod 'GoogleMaps'
 end
 
 post_install do |installer|

--- a/ios/Runner/PickerMapNativeView.swift
+++ b/ios/Runner/PickerMapNativeView.swift
@@ -33,6 +33,9 @@ class PickerMapNativeView: NSObject, FlutterPlatformView {
          let lng = user["longitude"] as? Double {
         let pos = CLLocationCoordinate2D(latitude: lat, longitude: lng)
         mapView.camera = GMSCameraPosition(latitude: lat, longitude: lng, zoom: 14)
+
+        let pad = dict["brandSafePaddingBottom"] as? Double ?? 0
+        mapView.padding = UIEdgeInsets(top: 0, left: 0, bottom: CGFloat(pad), right: 0)
         if userMarker == nil {
           userMarker = GMSMarker(position: pos)
           userMarker?.map = mapView

--- a/lib/home5/home5_widget.dart
+++ b/lib/home5/home5_widget.dart
@@ -359,7 +359,7 @@ class _Home5WidgetState extends State<Home5Widget>
                           driverTaxiIconUrl:
                               'https://storage.googleapis.com/flutterflow-io-6f20.appspot.com/projects/ride-899y4i/assets/hlhwt7mbve4j/ChatGPT_Image_3_de_set._de_2025%2C_15_02_50.png',
                           enableRouteSnake: true,
-                          brandSafePaddingBottom: 24.0,
+                          brandSafePaddingBottom: 60.0,
                           liteModeOnAndroid: false,
                           ultraLowSpecMode: false,
                         ),


### PR DESCRIPTION
## Summary
- set bottom safe-area padding for native maps on Android and iOS
- add Google Maps dependencies for platform-native views
- integrate PickerMapNativo on Home05 with 60px bottom padding

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c05c6e8b308331ab0c4ff61268f162