### PR TITLE
fix: remove invalid comments from AndroidManifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -20,16 +20,16 @@
         tools:replace="android:maxSdkVersion" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
+    <!-- IMPORTANTES para MapView/WebView -->
     <application
         android:name="${applicationName}"
         android:label="Ride Bahamas"
         tools:replace="android:label"
         android:icon="@mipmap/ic_launcher"
-
-        <!-- IMPORTANTES para MapView/WebView -->
         android:hardwareAccelerated="true"
-        android:usesCleartextTraffic="true"   <!-- opcional: útil em debug -->
+        android:usesCleartextTraffic="true"
         android:requestLegacyExternalStorage="true">
+        <!-- opcional: útil em debug -->
 
         <activity
             android:name=".MainActivity"


### PR DESCRIPTION
## Summary
- remove inline comments from AndroidManifest start tag to allow splash screen generation

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c33688bb5883318fb70c949ba55fcb