### PR TITLE
Fix Android splash screen resource definitions

### DIFF
--- a/android/app/src/main/res/values-night-v31/styles.xml
+++ b/android/app/src/main/res/values-night-v31/styles.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="LaunchTheme" parent="@style/Theme.SplashScreen">
-        <item name="windowSplashScreenBackground">@color/splash_color</item>
-        <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher</item>
-        <item name="postSplashScreenTheme">@style/NormalTheme</item>
+    <style name="LaunchTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
+        <item name="android:windowSplashScreenBackground">@color/splash_color</item>
+        <item name="android:windowSplashScreenAnimatedIcon">@mipmap/ic_launcher</item>
+        <item name="android:postSplashScreenTheme">@style/NormalTheme</item>
     </style>
 
-    <style name="NormalTheme" parent="@style/Theme.AppCompat.Light.NoActionBar">
+    <style name="NormalTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="android:windowBackground">@android:color/transparent</item>
     </style>
 </resources>

--- a/android/app/src/main/res/values-night/styles.xml
+++ b/android/app/src/main/res/values-night/styles.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="LaunchTheme" parent="@style/Theme.AppCompat.Light.NoActionBar">
+    <style name="LaunchTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="android:windowBackground">@drawable/launch_background</item>
     </style>
-    <style name="NormalTheme" parent="@style/Theme.AppCompat.Light.NoActionBar">
+    <style name="NormalTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="android:windowBackground">@android:color/transparent</item>
     </style>
 </resources>

--- a/android/app/src/main/res/values-v31/styles.xml
+++ b/android/app/src/main/res/values-v31/styles.xml
@@ -2,9 +2,9 @@
 <resources>
 
     <!-- Em v31+, use as attrs do Android 12 (note o prefixo android:) -->
-    <style name="LaunchTheme" parent="Theme.Material3.DayNight.NoActionBar">
+    <style name="LaunchTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="android:windowSplashScreenBackground">@color/splash_color</item>
-        <item name="android:windowSplashScreenAnimatedIcon">@mipmap/launch_image</item>
+        <item name="android:windowSplashScreenAnimatedIcon">@mipmap/ic_launcher</item>
         <item name="android:postSplashScreenTheme">@style/NormalTheme</item>
     </style>
 

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -2,12 +2,12 @@
 <resources>
 
     <!-- Tema usado depois do splash -->
-    <style name="NormalTheme" parent="Theme.Material3.DayNight.NoActionBar">
+    <style name="NormalTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="android:windowBackground">@android:color/white</item>
     </style>
 
     <!-- Tema de lançamento (pré-Android 12) -->
-    <style name="LaunchTheme" parent="Theme.Material3.DayNight.NoActionBar">
+    <style name="LaunchTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="android:windowBackground">@drawable/launch_background</item>
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowFullscreen">true</item>


### PR DESCRIPTION
## Summary
- switch Android themes to AppCompat DayNight to avoid missing Material3 resources
- replace non-existent launch image with launcher icon and correct Android 12 attributes

## Testing
- `flutter test` *(fails: LateInitializationError: Field '_prefs@854418973' has not been initialized)*
- `flutter build apk --debug` *(fails: No Android SDK found. Try setting the ANDROID_HOME environment variable.)*

------
https://chatgpt.com/codex/tasks/task_b_68c341ab28748331851ed0850dd700e7