### PR TITLE
Fix splash screen theme attribute

### DIFF
--- a/android/app/src/main/res/values-night-v31/styles.xml
+++ b/android/app/src/main/res/values-night-v31/styles.xml
@@ -3,6 +3,8 @@
     <style name="LaunchTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="android:windowSplashScreenBackground">@color/splash_color</item>
         <item name="android:windowSplashScreenAnimatedIcon">@mipmap/ic_launcher</item>
+        <!-- Use postSplashScreenTheme sem o prefixo android: -->
+        <item name="postSplashScreenTheme">@style/NormalTheme</item>
     </style>
 
     <style name="NormalTheme" parent="Theme.AppCompat.DayNight.NoActionBar">

--- a/android/app/src/main/res/values-v31/styles.xml
+++ b/android/app/src/main/res/values-v31/styles.xml
@@ -5,6 +5,8 @@
     <style name="LaunchTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="android:windowSplashScreenBackground">@color/splash_color</item>
         <item name="android:windowSplashScreenAnimatedIcon">@mipmap/ic_launcher</item>
+        <!-- Use postSplashScreenTheme sem o prefixo android: -->
+        <item name="postSplashScreenTheme">@style/NormalTheme</item>
     </style>
 
 </resources>


### PR DESCRIPTION
## Summary
- define `postSplashScreenTheme` correctly for Android 12+ splash screen styles

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c34a079a708331986c7b7a0bceacc6