### PR TITLE
Fix PickerMapNative widget and remove obsolete API key

### DIFF
--- a/lib/custom_code/widgets/picker_map_native.dart
+++ b/lib/custom_code/widgets/picker_map_native.dart
@@ -3,6 +3,7 @@ import 'dart:ui' as ui;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/gestures.dart';
 
 // Se estiver usando FlutterFlow, adapte imports de LatLng conforme seu projeto.
 // Aqui uso uma struct simples:
@@ -153,21 +154,23 @@ class _PickerMapNativeState extends State<PickerMapNative> {
       return const Center(child: Text('PickerMapNative: apenas Android'));
     }
 
-    final androidView = AndroidViewSurface(
-      controller: PlatformViewsService.initSurfaceAndroidView(
-        id: 0,
-        viewType: 'picker_map_native',
-        layoutDirection: ui.TextDirection.ltr,
-        creationParams: {
-          'initialUserLocation': {
-            'latitude': widget.userLocation.latitude,
-            'longitude': widget.userLocation.longitude,
-          },
+    final controller = PlatformViewsService.initSurfaceAndroidView(
+      id: 0,
+      viewType: 'picker_map_native',
+      layoutDirection: ui.TextDirection.ltr,
+      creationParams: {
+        'initialUserLocation': {
+          'latitude': widget.userLocation.latitude,
+          'longitude': widget.userLocation.longitude,
         },
-        creationParamsCodec: const StandardMessageCodec(),
-      )
-        ..addOnPlatformViewCreatedListener(_onPlatformViewCreated)
-        ..create() as AndroidViewController,
+      },
+      creationParamsCodec: const StandardMessageCodec(),
+    )
+      ..addOnPlatformViewCreatedListener(_onPlatformViewCreated)
+      ..create();
+
+    final androidView = AndroidViewSurface(
+      controller: controller as AndroidViewController,
       gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>{},
       hitTestBehavior: PlatformViewHitTestBehavior.opaque,
     );

--- a/lib/home5/home5_widget.dart
+++ b/lib/home5/home5_widget.dart
@@ -236,7 +236,6 @@ class _Home5WidgetState extends State<Home5Widget> with TickerProviderStateMixin
                         width: double.infinity,
                         height: double.infinity,
                         userLocation: FFAppState().latlngAtual!,
-                        googleApiKey: 'AIzaSyCFBfcNHFg97sM7EhKnAP4OHIoY3Q8Y_xQ',
                         driversRefs: pickerMapUsersRecordList.map((e) => e.reference).toList(),
                         destination: FFAppState().latlangAondeVaiIr,
                         refreshMs: 2000,


### PR DESCRIPTION
## Summary
- fix PickerMapNative platform view setup and gesture imports
- remove obsolete googleApiKey parameter from home screen map

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c498563bf48331bdd051952b532d2b