### PR TITLE
Fix night style theme parent

### DIFF
--- a/android/app/src/main/res/values-night-v31/styles.xml
+++ b/android/app/src/main/res/values-night-v31/styles.xml
@@ -12,7 +12,7 @@
          running.
          
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
-    <style name="NormalTheme" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="NormalTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="android:windowBackground">?android:colorBackground</item>
     </style>
 </resources>

--- a/android/app/src/main/res/values-night/styles.xml
+++ b/android/app/src/main/res/values-night/styles.xml
@@ -12,7 +12,7 @@
          running.
          
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
-    <style name="NormalTheme" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="NormalTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="android:windowBackground">?android:colorBackground</item>
     </style>
 </resources>


### PR DESCRIPTION
## Summary
- fix parent theme for night styles to use DayNight

## Testing
- `python - <<'PY'
import xml.etree.ElementTree as ET
for path in [
    'android/app/src/main/res/values/styles.xml',
    'android/app/src/main/res/values-night/styles.xml',
    'android/app/src/main/res/values-v31/styles.xml',
    'android/app/src/main/res/values-night-v31/styles.xml'
]:
    try:
        ET.parse(path)
        print(path, 'OK')
    except Exception as e:
        print(path, 'ERROR', e)
PY`


------
https://chatgpt.com/codex/tasks/task_b_68c5a2a055888331b619e3b8fa162b47