### PR TITLE
Keep map centered on user with avatar overlay

### DIFF
--- a/lib/app_state.dart
+++ b/lib/app_state.dart
@@ -205,10 +205,12 @@ class FFAppState extends ChangeNotifier {
   LatLng? _latlngAtual = LatLng(25.0443312, -77.3503609);
   LatLng? get latlngAtual => _latlngAtual;
   set latlngAtual(LatLng? value) {
+    if (value == null) {
+      // Ignora atualizações nulas para evitar estado inconsistente.
+      return;
+    }
     _latlngAtual = value;
-    value != null
-        ? prefs.setString('ff_latlngAtual', value.serialize())
-        : prefs.remove('ff_latlngAtual');
+    prefs.setString('ff_latlngAtual', value.serialize());
   }
 
   LatLng? _latlangAondeVaiIr;

--- a/lib/custom_code/widgets/picker_map_native.dart
+++ b/lib/custom_code/widgets/picker_map_native.dart
@@ -186,6 +186,42 @@ class _PickerMapNativeState extends State<PickerMapNative> {
     super.dispose();
   }
 
+  @override
+  void didUpdateWidget(covariant PickerMapNative oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    final newUser = _safe(widget.userLocation);
+    final oldUser = _safe(oldWidget.userLocation);
+    final destChanged = widget.destination != oldWidget.destination;
+    final userChanged = newUser != oldUser;
+    final photoChanged = widget.userPhotoUrl != oldWidget.userPhotoUrl;
+    final nameChanged = widget.userName != oldWidget.userName;
+
+    if (_channel != null && (userChanged || destChanged || photoChanged || nameChanged)) {
+      _channel!.invokeMethod('updateConfig', {
+        'userLocation': {
+          'latitude': newUser.latitude,
+          'longitude': newUser.longitude,
+        },
+        if (widget.destination != null)
+          'destination': {
+            'latitude': widget.destination!.latitude,
+            'longitude': widget.destination!.longitude,
+          },
+        'userName': widget.userName,
+        'userPhotoUrl': widget.userPhotoUrl,
+      });
+
+      if (userChanged) {
+        _channel!.invokeMethod('cameraTo', {
+          'latitude': newUser.latitude,
+          'longitude': newUser.longitude,
+          'zoom': 15.0,
+        });
+      }
+    }
+  }
+
   Future<void> _onPlatformViewCreated(int id) async {
     _channel = MethodChannel('picker_map_native_$id');
     _channel!.setMethodCallHandler(_handleCall);

--- a/lib/home5/home5_widget.dart
+++ b/lib/home5/home5_widget.dart
@@ -48,6 +48,13 @@ class _Home5WidgetState extends State<Home5Widget> with TickerProviderStateMixin
       (p.latitude.abs() < 0.000001 && p.longitude.abs() < 0.000001);
   LatLng _safe(LatLng? p) => (p == null || _isZero(p)) ? _kNassau : p;
 
+  String _initials(String? name) {
+    if (name == null || name.trim().isEmpty) return '';
+    final parts = name.trim().split(RegExp(r'\s+'));
+    if (parts.length == 1) return parts.first[0].toUpperCase();
+    return (parts.first[0] + parts.last[0]).toUpperCase();
+  }
+
   var hasContainerTriggered1 = false;
   var hasContainerTriggered2 = false;
   var hasContainerTriggered3 = false;
@@ -233,6 +240,33 @@ class _Home5WidgetState extends State<Home5Widget> with TickerProviderStateMixin
                       );
                     },
                   ),
+                ),
+              ),
+            ),
+            Align(
+              alignment: Alignment.center,
+              child: IgnorePointer(
+                child: Container(
+                  width: 40,
+                  height: 40,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: FlutterFlowTheme.of(context).secondaryBackground,
+                    image: (currentUserPhoto != '')
+                        ? DecorationImage(
+                            image: NetworkImage(currentUserPhoto),
+                            fit: BoxFit.cover,
+                          )
+                        : null,
+                  ),
+                  child: (currentUserPhoto != '')
+                      ? null
+                      : Center(
+                          child: Text(
+                            _initials(currentUserDisplayName),
+                            style: FlutterFlowTheme.of(context).titleSmall,
+                          ),
+                        ),
                 ),
               ),
             ),


### PR DESCRIPTION
## Summary
- ignore null location updates to avoid clearing stored coordinates
- refresh native map when user location, destination, or avatar changes
- overlay user photo/initials to show current position

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c7411fba048331a1c27cb0f448f52d